### PR TITLE
Do not use rand() in the delay function

### DIFF
--- a/test/test_syscalls.c
+++ b/test/test_syscalls.c
@@ -149,8 +149,8 @@ static char *strings[5][3] = {
 	},
 };
 
-#define N_ITERATIONS		1000000
-static int counter;
+#define N_ITERATIONS		4000000
+volatile unsigned counter;
 static int do_wait;
 
 /*
@@ -163,7 +163,7 @@ s()
 		return;
 
 	for (int i = 0; i < N_ITERATIONS; i++)
-		counter += rand();
+		counter++;
 }
 
 /*


### PR DESCRIPTION
rand() is considered as a potentially dangerous function by Coverity.
It does not matter in this case of course, but Coverity reports it
as an issue anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vltrace/33)
<!-- Reviewable:end -->
